### PR TITLE
fix: remove unused struct

### DIFF
--- a/search.go
+++ b/search.go
@@ -57,9 +57,6 @@ type CustomOrderSearchBody struct {
 			} `json:"associations"`
 		} `json:"deliveries"`
 	} `json:"associations"`
-	Includes struct {
-		Product []string `json:"product"`
-	} `json:"includes"`
 }
 
 type CustomOrderSearchBodyFilter struct {


### PR DESCRIPTION
Removes unused 'Includes' struct from the Go backend, simplifying the data model.
